### PR TITLE
Button fix for Add user in Admin panel

### DIFF
--- a/orochi/users/admin.py
+++ b/orochi/users/admin.py
@@ -12,6 +12,22 @@ class UserAdmin(auth_admin.UserAdmin):
 
     form = UserChangeForm
     add_form = UserCreationForm
-    fieldsets = (("User", {"fields": ("name",)}),) + auth_admin.UserAdmin.fieldsets
+    fieldsets = (
+        (None, {"fields": ("username", "password")}),
+        ("Personal info", {"fields": ("first_name", "last_name", "email", "name")}),
+        (
+            "Permissions",
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
+            },
+        ),
+        ("Important dates", {"fields": ("last_login", "date_joined")}),
+    )
     list_display = ["username", "name", "is_superuser"]
     search_fields = ["name"]

--- a/orochi/users/admin.py
+++ b/orochi/users/admin.py
@@ -9,7 +9,6 @@ User = get_user_model()
 
 @admin.register(User)
 class UserAdmin(auth_admin.UserAdmin):
-
     form = UserChangeForm
     add_form = UserCreationForm
     fieldsets = (

--- a/orochi/users/admin.py
+++ b/orochi/users/admin.py
@@ -29,5 +29,27 @@ class UserAdmin(auth_admin.UserAdmin):
         ),
         ("Important dates", {"fields": ("last_login", "date_joined")}),
     )
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": ("username", "password1", "password2"),
+            },
+        ),
+        ("Personal info", {"fields": ("first_name", "last_name", "email", "name")}),
+        (
+            "Permissions",
+            {
+                "fields": (
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "groups",
+                    "user_permissions",
+                ),
+            },
+        ),
+    )
     list_display = ["username", "name", "is_superuser"]
     search_fields = ["name"]


### PR DESCRIPTION
Button fix for Add user in Admin panel, 

500 error

The template  orochi/templates/admin/base.html at line 63, there's a reference to user.has_usable_password. This is a method call in the template, not a field. However, the real issue is that we need to also check if there's an add_fieldsets attribute that needs to be defined.

The issue was that Django's UserAdmin uses two different fieldset configurations:

fieldsets for editing existing users
add_fieldsets for creating new users
We had only defined fieldsets, so when Django tried to render the "add user" form, it fell back to the parent class's add_fieldsets which included the usable_password field that doesn't exist on your custom User model.