### PR TITLE
fix: sanitize shell/subprocess call in plugin_install.py

### DIFF
--- a/orochi/utils/plugin_install.py
+++ b/orochi/utils/plugin_install.py
@@ -30,8 +30,20 @@ def plugin_install(plugin_path):
             finally:
                 os.remove(script_path)
         if reqs_script:
-            os.system("pip install 'setuptools<70' wheel six cffi")
-            os.system(f"pip install --no-build-isolation -r {tmp_folder}/requirements.txt")
+            subprocess.run(
+                ["pip", "install", "setuptools<70", "wheel", "six", "cffi"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "pip",
+                    "install",
+                    "--no-build-isolation",
+                    "-r",
+                    str(Path(tmp_folder) / "requirements.txt"),
+                ],
+                check=True,
+            )
 
     try:
         bash_script = None


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `orochi/utils/plugin_install.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `orochi/utils/plugin_install.py:33` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The plugin_install function uses os.system to execute pip install commands with user-controlled paths. The tmp_folder path is interpolated directly into shell commands without sanitization, allowing command injection if the path contains shell metacharacters.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `orochi/utils/plugin_install.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->
